### PR TITLE
doc(mcu.ino): add comments for documentation

### DIFF
--- a/mcu/mcu.ino
+++ b/mcu/mcu.ino
@@ -147,6 +147,8 @@ void flush_buffer(int* buffer, int* buf_ind) {
 
 // Executes the packet `packet` based on the two significant bytes. The first byte indicates the
 // command to be executed, and the second byte indicates the argument for the command.
+// Executes the commands based on the following document:
+// https://docs.google.com/document/d/1TtKtFwUutYwbIac_FjjTdN0an4Zpzbw5fHmSIN9APws/edit
 void execute_packet(int* packet) {
   int cmd_byte = packet[0];
   int arg_byte = packet[1];


### PR DESCRIPTION
Header explains the purpose of the file and provides the GPLv3 license
boilerplate.

Program's constants and definitions are explained with comments.
User-defined functions are explained with comments, so that those
unfamiliar with the program have a better grasp of what is happening.

Made `115200` into the constant `BAUD_RATE` to remove the use of a
potentially unclear magic number.

Signed-off-by: Lucas Sta Maria <lucas.stamaria@gmail.com>